### PR TITLE
Version v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pg_tps_optimizer"
-version = "0.1.4"
+version = "0.2.2"
 dependencies = [
  "args",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_tps_optimizer"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Sebastiaan Mannem <sebastiaan.mannem@enterprisedb.com>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,16 +23,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut threader = threader::Threader::new(max_threads as usize, w);
     let mut sampler = pg_sampler::PgSampler::new(args.as_dsn())?;
     sampler.next()?;
+    let mut instable: bool = false;
 
     println!("min threads: {} max threads: {}", min_threads, max_threads);
 
-    println!("|---------------------|---------|---------------------------------------|-----------------------|");
-    println!("| Date       time     | Clients |               Performance             |       Postgres        |");
-    println!("|                     |         |-------------|-----------|-------------|-----------|-----------|");
-    println!("|                     |         |    TPS      |  Latency  | TPS/Latency |   TPS     |    wal    |");
-    println!("|                     |         |             |   (usec)  |             |           |    kB/s   |");
-    println!("|---------------------|---------|-------------|---- -------|-------------|-----------|-----------|");
-    //        2019-06-24 11:33:23 |       1 | 2.105.090 |  10.121 | 2.168.312 | 1.105.131 |
+    println!("|---------------------|---------|-----------------------------------------|-----------------------|");
+    println!("| Date       time     | Clients |                 Performance             |       Postgres        |");
+    println!("|                     |         |---------------|-----------|-------------|-----------|-----------|");
+    println!("|                     |         |      TPS      |  Latency  | TPS/Latency |   TPS     |    wal    |");
+    println!("|                     |         |               |   (usec)  |             |           |    kB/s   |");
+    println!("|---------------------|---------|---------------|-----------|-------------|-----------|-----------|");
 
     for num_threads in Fibonacci::new(1_u32, 1_u32).take_while(|v| *v < max_threads) {
         if num_threads < min_threads {
@@ -45,10 +45,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 sampler.next()?;
                 let latency = result.latency.num_microseconds().unwrap() as f64;
                 let pg_tps: f64 = sampler.tps() as f64;
+                if !result.stable {
+                    instable = true;
+                }
                 println!(
-                    "| {0} | {1:7.5} | {2:>11.3} | {3:>9.1} | {4:>11.3} | {5:>9.3} | {6:>9.3} |",
+                    "| {0} | {1:7.5} | {2} {3:>11.3} | {4:>9.1} | {5:>11.3} | {6:>9.3} | {7:>9.3} |",
                     chrono::offset::Local::now().format("%Y-%m-%d %H:%M:%S"),
                     num_threads,
+                    match result.stable {
+                        true => " ",
+                        _ => "*",
+                    },
                     result.tps,
                     latency,
                     result.tps / latency,
@@ -57,22 +64,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     );
             }
             None => {
-                println!(
-                    "| {0} | {1:7.5} | {2:>11.3} | {3:>9.1} | {4:>11.3} | {5:>9.3} | {6:>9.3} |",
-                    chrono::offset::Local::now().format("%Y-%m-%d %H:%M:%S"),
-                    num_threads,
-                    "?",
-                    "?",
-                    "?",
-                    "?",
-                    "?"
-                    );
+                println!("| {0} | {1:7.5} |   {2:>11.3} | {3:>9.1} | {4:>11.3} | {5:>9.3} | {6:>9.3} |",
+                         chrono::offset::Local::now().format("%Y-%m-%d %H:%M:%S"),
+                         num_threads, "?", "?", "?", "?", "?");
                 break;
             }
         }
     }
-    println!("|---------------------|---------|-------------|---------|-------------|-----------|-----------|");
+    println!("|---------------------|---------|---------------|-----------|-------------|-----------|-----------|");
 
+    if instable {
+        println!("* Samples marked with '*' did not stabilize before max-wait.")
+    }
     println!("Stopping, but lets give the threads some time to stop");
     threader.finish();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,12 +26,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("min threads: {} max threads: {}", min_threads, max_threads);
 
-    println!("|---------------------|---------|-------------------------------------|-----------------------|");
-    println!("| Date       time     | Clients |              Performance            |       Postgres        |");
-    println!("|                     |         |-------------|---------|-------------|-----------|-----------|");
-    println!("|                     |         |    TPS      | Latency | TPS/Latency |   TPS     |    wal    |");
-    println!("|                     |         |             | (usec)  |             |           |    kB/s   |");
-    println!("|---------------------|---------|-------------|---------|-------------|-----------|-----------|");
+    println!("|---------------------|---------|---------------------------------------|-----------------------|");
+    println!("| Date       time     | Clients |               Performance             |       Postgres        |");
+    println!("|                     |         |-------------|-----------|-------------|-----------|-----------|");
+    println!("|                     |         |    TPS      |  Latency  | TPS/Latency |   TPS     |    wal    |");
+    println!("|                     |         |             |   (usec)  |             |           |    kB/s   |");
+    println!("|---------------------|---------|-------------|---- -------|-------------|-----------|-----------|");
     //        2019-06-24 11:33:23 |       1 | 2.105.090 |  10.121 | 2.168.312 | 1.105.131 |
 
     for num_threads in Fibonacci::new(1_u32, 1_u32).take_while(|v| *v < max_threads) {
@@ -45,41 +45,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 sampler.next()?;
                 let latency = result.latency.num_microseconds().unwrap() as f64;
                 let pg_tps: f64 = sampler.tps() as f64;
-                if result.tps / pg_tps > 10_f64 {
-                    println!(
-                        "| {0} | {1:7.5} | OVEREXCITED | {2:>7.1} | OVEREXCITED | {3:>9.3} | {4:>9.3} |",
-                        chrono::offset::Local::now().format("%Y-%m-%d %H:%M:%S"),
-                        num_threads,
-                        latency,
-                        sampler.tps(),
-                        sampler.wal_per_sec() as i32,
-                        );
-                } else if result.tps < 1_f64 {
-                    println!(
-                        "| {0} | {1:7.5} |  TOO_SMALL  | {2:>7.1} |  TOO_SMALL  | {3:>9.3} | {4:>9.3} |",
-                        chrono::offset::Local::now().format("%Y-%m-%d %H:%M:%S"),
-                        num_threads,
-                        latency,
-                        sampler.tps(),
-                        sampler.wal_per_sec() as i32,
-                        );
-                    break;
-                } else {
-                    println!(
-                        "| {0} | {1:7.5} | {2:>11.3} | {3:>7.1} | {4:>11.3} | {5:>9.3} | {6:>9.3} |",
-                        chrono::offset::Local::now().format("%Y-%m-%d %H:%M:%S"),
-                        num_threads,
-                        result.tps,
-                        latency,
-                        result.tps / latency,
-                        pg_tps,
-                        sampler.wal_per_sec() as i32,
-                        );
-                }
+                println!(
+                    "| {0} | {1:7.5} | {2:>11.3} | {3:>9.1} | {4:>11.3} | {5:>9.3} | {6:>9.3} |",
+                    chrono::offset::Local::now().format("%Y-%m-%d %H:%M:%S"),
+                    num_threads,
+                    result.tps,
+                    latency,
+                    result.tps / latency,
+                    pg_tps,
+                    sampler.wal_per_sec() as i32,
+                    );
             }
             None => {
                 println!(
-                    "| {0} | {1:7.5} | {2:>11.3} | {3:>7.1} | {4:>11.3} | {5:>9.3} | {6:>9.3} |",
+                    "| {0} | {1:7.5} | {2:>11.3} | {3:>9.1} | {4:>11.3} | {5:>9.3} | {6:>9.3} |",
                     chrono::offset::Local::now().format("%Y-%m-%d %H:%M:%S"),
                     num_threads,
                     "?",

--- a/src/threader/mod.rs
+++ b/src/threader/mod.rs
@@ -87,11 +87,12 @@ impl Threader {
     ) -> Option<TestResult> {
         let end_time = Utc::now() + max_wait;
         let mut parallel_samples = ParallelSamples::new();
-        let i: usize = 0;
+        let mut i: usize = 0;
         loop {
             if i > count && Utc::now() > end_time {
                 break;
             }
+            i += 1;
             let s = self.consume();
             parallel_samples = parallel_samples.append(&s);
             let test_result = parallel_samples.as_results(count, count + 1);

--- a/src/threader/mod.rs
+++ b/src/threader/mod.rs
@@ -89,25 +89,22 @@ impl Threader {
         let mut parallel_samples = ParallelSamples::new();
         let mut i: usize = 0;
         loop {
-            if i > count && Utc::now() > end_time {
-                break;
-            }
-            i += 1;
             let s = self.consume();
             parallel_samples = parallel_samples.append(&s);
-            let test_result = parallel_samples.as_results(count, count + 1);
+            let test_results = parallel_samples.as_results(count, count + 1);
             //            let stddev = test_result.std_deviation_absolute().unwrap();
             //            println!("tps: {}, latency: {}", stddev.tps, stddev.latency);
-            match test_result.verify(spread) {
+            if i > count && Utc::now() > end_time {
+                return test_results.mean();
+            }
+            i += 1;
+            match test_results.verify(spread) {
                 Some(test_result) => {
                     return Some(test_result);
                 }
-                None => {
-                    continue;
-                }
+                None => (),
             }
         }
-        None
     }
 
     fn consume(&mut self) -> ParallelSamples {

--- a/src/threader/worker.rs
+++ b/src/threader/worker.rs
@@ -59,7 +59,7 @@ impl Worker {
                     break;
                 }
             }
-            match sample(&mut client, self.workload.w_type(), tps / 10_f64, self.id) {
+            match sample(&mut client, self.workload.w_type(), (tps / 10_f64) as u64, self.id) {
                 Ok(sample) => {
                     //tps = samples.tot_tps_singlethread() as u64;
                     let mut pss = ParallelSamples::new();
@@ -82,16 +82,16 @@ impl Worker {
 fn sample(
     client: &mut Client,
     w_type: WorkloadType,
-    mut num_queries: f64,
+    mut num_queries: u64,
     thread_id: u32,
 ) -> Result<Sample, postgres::Error> {
-    if num_queries < 1_f64 {
-        num_queries = 1_f64;
+    if num_queries < 1 {
+        num_queries = 1;
     }
     let mut s = Sample::new();
     let query = format!("update {} set id=$1 where id=$1", TABLE_NAME);
 
-    for _x in 1..(num_queries as u64) {
+    for _x in 0..num_queries {
         let start = Utc::now();
         match w_type {
             WorkloadType::Prepared => {


### PR DESCRIPTION
- keeping 100 samples instead of 10
- Moving to a solution with downscaling, part 1: using ParallelSamples all the way
- DOwnscaling implemented. V1
- Version v.2.0
- Upgrading to f64
- Releasing v0.2.1
- fixing Worker.procedure() to run at least 1 query
- Fixing timeout
- Also printing samples that did not stabilize in time
- New release v0.2.2
